### PR TITLE
Fixed package removal and removed unnecessary package.

### DIFF
--- a/installer/arch/prepare
+++ b/installer/arch/prepare
@@ -59,7 +59,7 @@ install_pkg_dist() {
 # remove_dist: see remove() in prepare.sh for details.
 remove_dist() {
     if [ "$#" -gt 0 ]; then
-        pacman -R "$@"
+        pacman -R --noconfirm "$@"
     fi
 }
 

--- a/targets/xorg
+++ b/targets/xorg
@@ -104,10 +104,9 @@ END
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-install xorg arch=,xserver-xorg-video-fbdev$ltspackages
-if [ "${ARCH#arm}" = "$ARCH" ]; then
-    install arch=,xserver-xorg-video-intel$ltspackages
-fi
+install xorg arch=,xserver-xorg-video-fbdev$ltspackages arch=,xserver-xorg-video-intel$ltspackages
+# JMT: eventually wrap this removal with an appropriate test
+remove xf86-video-odroid-c1
 
 # This is a system with framebuffer compression, so we need SNA+tearfree
 xorgconf='/usr/share/X11/xorg.conf.d/20-crouton-intel-sna.conf'

--- a/targets/xorg
+++ b/targets/xorg
@@ -104,7 +104,10 @@ END
     apt-get -y --force-yes --no-install-recommends dist-upgrade -f
 fi
 
-install xorg arch=,xserver-xorg-video-fbdev$ltspackages arch=,xserver-xorg-video-intel$ltspackages
+install xorg arch=,xserver-xorg-video-fbdev$ltspackages
+if [ "${ARCH#arm}" = "$ARCH" ]; then
+    install arch=,xserver-xorg-video-intel$ltspackages
+fi
 # JMT: eventually wrap this removal with an appropriate test
 remove xf86-video-odroid-c1
 


### PR DESCRIPTION
The package xf86-video-odroid-c1 contributes a file to xorg.conf.d
which causes xinit to not work correctly in tests.  Removing this
package required an additional change to the installer to force
removals without asking for confirmation.
