### PR TITLE
Skip libncursesw.so when installing new chroot

### DIFF
--- a/installer/arch/bootstrap
+++ b/installer/arch/bootstrap
@@ -97,6 +97,13 @@ while [ -n "$missing" ]; do
     package="${missing%% *}"
     missing="${missing#$package }"
 
+# Skip libncursesw.so and continue installation
+if [ "$package" = "libncursesw.so" ]; then 
+    echo "skipping $package"
+    installed="$installed $package "
+    continue
+fi;
+
     # Do not install if already installed
     if [ "${installed#*" $package "}" != "$installed" ]; then
         continue


### PR DESCRIPTION
supremexbraxas found a solution to an issue I was having with installing Arch Linux through a chroot. Every time I attempted to install, libncursesw.so stops the installation. I added supremexbraxas' code to chroagh/installer/arch/bootstrap so it doesn't stop the installation.

Code was found here:
https://github.com/drinkcat/chroagh/issues/100
