### PR TITLE
Fix for tar encountering existing .BUILDINFO files

### DIFF
--- a/installer/arch/bootstrap
+++ b/installer/arch/bootstrap
@@ -117,6 +117,7 @@ while [ -n "$missing" ]; do
     tar --warning=no-unknown-keyword -xkf "$FETCHDIRPKG/$file" \
         --exclude=".PKGINFO" --exclude=".MTREE" \
         --exclude=".INSTALL" --exclude=".Changelog" \
+        --overwrite \
         -C "$BOOTSTRAPCHROOT"
 
     # Get list of dependencies (ignore versions)


### PR DESCRIPTION
This PR simply tells tar to overwite any files during extraction.  In particular, errors could pop up from .BUILDINFO files being present which would crash the bootstrap script.  Some users report libgcrypt package exhibited this behavior, but I personally saw the same behavior with the libsystemd package during installation.
